### PR TITLE
course:update ability instead of course:create

### DIFF
--- a/context/course/classes/context_handler.php
+++ b/context/course/classes/context_handler.php
@@ -108,7 +108,7 @@ class context_handler extends \local_metadata\context\context_handler {
      */
     public function require_access() {
         require_login($this->instance);
-        require_capability('moodle/course:create', $this->context);
+        require_capability('moodle/course:update', $this->context);
         return true;
     }
 


### PR DESCRIPTION
Hello,
I feel more fair to use course:update in the needed capacity for courses metadata.
I updated mine this way because teachers can't create but can update courses. Creation is only allowed to special profiles to avoid too many mess.
Thanks by the way for this plugin allowing me to do wonderful automated things based on course related special metadata ;)