### PR TITLE
32 Fix Use of undefined constant CONTEXT_COHORT

### DIFF
--- a/context/cohort/classes/observer.php
+++ b/context/cohort/classes/observer.php
@@ -26,6 +26,8 @@ namespace metadatacontext_cohort;
 
 defined('MOODLE_INTERNAL') || die();
 
+require_once($CFG->dirroot . '/local/metadata/context/cohort/classes/context_handler.php');
+
 /**
  * Local metadatacontext_cohort event handler.
  */

--- a/context/cohort/tests/metadatacontext_cohort_event_test.php
+++ b/context/cohort/tests/metadatacontext_cohort_event_test.php
@@ -57,12 +57,14 @@ class metadatacontext_cohort_event_testcase extends advanced_testcase {
      */
     public function test_cohortdeleted() {
         global $DB, $CFG;
-        require_once($CFG->dirroot . '/local/metadata/context/cohort/classes/context_handler.php');
 
         $this->resetAfterTest(true);
 
+        // Don't declare CONTEXT_COHORT as this distorts the test
+        $contextcohort = 9000;
+
         // Create a custom field of textarea type.
-        $id1 = $this->generator->create_metadata_field(CONTEXT_COHORT, 'frogdesc', 'Description of frog');
+        $id1 = $this->generator->create_metadata_field($contextcohort, 'frogdesc', 'Description of frog');
         $this->generator->create_metadata($id1, $this->cohort[0]->id, 'Leopard frog');
         $this->generator->create_metadata($id1, $this->cohort[1]->id, 'Bullfrog');
 

--- a/context/group/classes/observer.php
+++ b/context/group/classes/observer.php
@@ -26,6 +26,8 @@ namespace metadatacontext_group;
 
 defined('MOODLE_INTERNAL') || die();
 
+require_once($CFG->dirroot . '/local/metadata/context/group/classes/context_handler.php');
+
 /**
  * Local metadatacontext_group event handler.
  */

--- a/context/group/tests/metadatacontext_group_event_test.php
+++ b/context/group/tests/metadatacontext_group_event_test.php
@@ -55,16 +55,18 @@ class metadatacontext_group_event_testcase extends advanced_testcase {
     }
 
     /**
-     * Performs unit tests for cohort deleted event.
+     * Performs unit tests for group deleted event.
      */
-    public function test_cohortdeleted() {
+    public function test_groupdeleted() {
         global $DB, $CFG;
-        require_once($CFG->dirroot . '/local/metadata/context/group/classes/context_handler.php');
 
         $this->resetAfterTest(true);
 
+        // Don't declare CONTEXT_GROUP as this distorts the test
+        $contextgroup = 60;
+
         // Create a custom field of textarea type.
-        $id1 = $this->generator->create_metadata_field(CONTEXT_GROUP, 'frogdesc', 'Description of frog');
+        $id1 = $this->generator->create_metadata_field($contextgroup, 'frogdesc', 'Description of frog');
         $this->generator->create_metadata($id1, $this->group[0]->id, 'Leopard frog');
         $this->generator->create_metadata($id1, $this->group[1]->id, 'Bullfrog');
 


### PR DESCRIPTION
Previously deleting a cohort or group the error "Use of undefined constant CONTEXT_COHORT" or "Use of undefined constant CONTEXT_GROUP" would occur.  This change also removes the require_once() from the PHPUnit test as this brought these constants into scope causing the test to pass when it should have failed (because of this problem).